### PR TITLE
select: don't prefer ERMS/FSRM if they're available

### DIFF
--- a/src/select.h
+++ b/src/select.h
@@ -1,7 +1,4 @@
 static memcpy_t *CONCAT(select_, FUNCTION)(void) {
-    if (erms || fsrm)
-        return CONCAT(FUNCTION, _erms);
-
     if (avx512f && !prefer_no_avx512) {
         if (avx512vl) {
             if (erms)


### PR DESCRIPTION
c0df1da incorrectly translated logic from glibc: `Prefer_{ERMS,FSRM}` was rewritten as `{ERMS,FSRM}`, but glibc never *prefers* these.